### PR TITLE
Add drizzle-kit push:mysql script

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'drizzle-kit'
+import 'dotenv/config'
 
 export default {
   schema: './src/lib/db/schema.ts',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "migrations:generate": "drizzle-kit generate:mysql",
     "migrations:push": "node -r esbuild-register src/lib/db/migrate.ts",
+    "db:push": "drizzle-kit push:mysql",
     "migrations:drop": "drizzle-kit drop --config=drizzle.config.ts"
   },
   "dependencies": {


### PR DESCRIPTION
This is an alternative way to run your migrations on PlanetScale without using any migration files and tracking table in your database.

- [x]  Changes were tested locally and schema changes were applied successfully

---

Drizzle Kit itself should be used only locally and not pushed to a bundle to be deployed. It means you can exclude `drizzle.config.ts` from being bundled and can use any dependencies you need (even those that are not edge-compatible).

## Changes
In this PR, you can see 2 changes:

1. Add a script to package.json.
2. Import `.env` variables to `drizzle.config.ts`. As long as it's a separate process of creating and pushing the migrations, it has nothing to do with other project setups like Next or any other library.

## Usage explanation
1. Anytime you change your schema in ts code and are ready to push it to your dev/feature branches on PlanetScale, run the `db:push` script from `package.json`. It will sync your schema with the database and warn if any data-loss actions will be applied.
2. When you are ready with a feature, deploy your code and invoke branch merging on the PlanetScale side so the database will be in sync with your code.

## Useful tips
If you want to exclude some tables from syncing with your database, you can use the filters option in the Drizzle Kit config.
Refer to this link for more information: https://orm.drizzle.team/kit-docs/conf#multi-project-schema

In this case, you can exclude some tables from being deleted while syncing the schema with your code.