### PR TITLE
Add links to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Starter-kit for Planetscale & DrizzleORM created by Josh
+Starter-kit for [Planetscale](https://planetscale.com/) & [DrizzleORM](https://github.com/drizzle-team/drizzle-orm) created by [Josh](https://github.com/joschan21)


### PR DESCRIPTION
I didn't know what PlanetScale or DrizzleORM was, and after reading the description of [the video](https://www.youtube.com/watch?v=8met6WTk0mQ) I only found the link to this repository, so I thought that adding links to some things would be a good idea :)

Also, maybe adding a link to PlanetScale and DrizzleORM on the video description would also be a good idea.